### PR TITLE
fix(rdp): prevent crash after minimizing fullscreen RDP (#3202)

### DIFF
--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
@@ -1793,8 +1793,10 @@ namespace mRemoteNG.Connection.Protocol.RDP
                         {
                             await System.Threading.Tasks.Task.Delay(100);
 
-                            if (_frmMain == null || _frmMain.IsDisposed) return;
+                            if (_frmMain == null || _frmMain.IsDisposed || !_frmMain.IsHandleCreated) return;
 
+                            try
+                            {
                             _frmMain.Invoke((MethodInvoker)delegate
                             {
                                 IntPtr hwnd = NativeMethods.GetForegroundWindow();
@@ -1844,6 +1846,8 @@ namespace mRemoteNG.Connection.Protocol.RDP
                                     fixApplied = true;
                                 }
                             });
+                            }
+                            catch (ObjectDisposedException) { return; }
 
                             if (fixApplied) break;
                         }
@@ -1862,13 +1866,44 @@ namespace mRemoteNG.Connection.Protocol.RDP
 
         private void RDPEvent_OnLeaveFullscreenMode()
         {
-            Fullscreen = false;
-            // Restore SmartSize to the state it was in before entering fullscreen (#1402).
-            SmartSize = _smartSizeBeforeFullscreen;
+            try
+            {
+                Fullscreen = false;
+                // Restore SmartSize to the state it was in before entering fullscreen (#1402).
+                SmartSize = _smartSizeBeforeFullscreen;
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionStackTrace("RDP leave-fullscreen state restore failed", ex, MessageClass.WarningMsg, false);
+            }
+
             _leaveFullscreenEvent?.Invoke(this, EventArgs.Empty);
 
             try
             {
+                if (_frmMain == null || _frmMain.IsDisposed) return;
+
+                if (_frmMain.InvokeRequired)
+                {
+                    _frmMain.BeginInvoke(new MethodInvoker(RestoreAfterFullscreen));
+                }
+                else
+                {
+                    RestoreAfterFullscreen();
+                }
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionStackTrace("RDP leave-fullscreen refocus failed", ex, MessageClass.WarningMsg, false);
+            }
+        }
+
+        private void RestoreAfterFullscreen()
+        {
+            try
+            {
+                if (_frmMain == null || _frmMain.IsDisposed) return;
+
                 if (_frmMain.WindowState == FormWindowState.Minimized && !Properties.OptionsTabsPanelsPage.Default.DoNotRestoreOnRdpMinimize)
                 {
                     _frmMain.WindowState = FormWindowState.Normal;
@@ -1893,7 +1928,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
             }
             catch (Exception ex)
             {
-                Runtime.MessageCollector.AddExceptionStackTrace("RDP leave-fullscreen refocus failed", ex, MessageClass.WarningMsg, false);
+                Runtime.MessageCollector.AddExceptionStackTrace("RDP leave-fullscreen restore failed", ex, MessageClass.WarningMsg, false);
             }
         }
 


### PR DESCRIPTION
## Summary
- Fixes upstream [#3202](https://github.com/mRemoteNG/mRemoteNG/issues/3202): crash when opening another connection after minimizing a fullscreen RDP session
- RDP COM events fire on non-UI thread; `LeaveFullscreenMode` accessed `_rdpClient` and `_frmMain` without disposal guards or UI thread marshaling

## Changes
- Wrap `Fullscreen`/`SmartSize` property restore in try/catch (COM object may be disposed during transition)
- Extract `RestoreAfterFullscreen()` and marshal to UI thread via `BeginInvoke` (was direct access from COM thread)
- Add `IsDisposed` + `IsHandleCreated` guards before `_frmMain.Invoke` in enter-fullscreen async task
- Catch `ObjectDisposedException` in enter-fullscreen retry loop (race between form disposal and async task)

## Test plan
- [ ] Open RDP connection → fullscreen → minimize → open another connection (should not crash)
- [ ] Verify fullscreen enter/exit still works correctly (taskbar button, monitor positioning)
- [ ] Verify SmartSize restores after leaving fullscreen
- [ ] Build passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)