### PR TITLE
Eliminate all build warnings and unblock the test suite on Windows 11 23H2

### DIFF
--- a/ExternalConnectors/CPS/CPSConnectionForm.Designer.cs
+++ b/ExternalConnectors/CPS/CPSConnectionForm.Designer.cs
@@ -230,7 +230,6 @@
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         public System.Windows.Forms.CheckBox cbUseSSO;

--- a/ExternalConnectors/ExternalConnectors.csproj
+++ b/ExternalConnectors/ExternalConnectors.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="VaultSharp" />
-    <PackageReference Include="System.DirectoryServices" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="AWS\AWSConnectionForm.cs" />

--- a/mRemoteNG/App/DevLog.cs
+++ b/mRemoteNG/App/DevLog.cs
@@ -11,7 +11,7 @@ namespace mRemoteNG.App
     /// </summary>
     internal static class DevLog
     {
-        private static readonly object _lock = new();
+        private static readonly Lock _lock = new();
         private static string? _logPath;
         private static bool _initialized;
         private static bool _enabled;
@@ -58,7 +58,7 @@ namespace mRemoteNG.App
 
         private static void WriteCore(string message, string? caller)
         {
-            string line = $"{DateTime.Now:HH:mm:ss.fff} [{Thread.CurrentThread.ManagedThreadId,3}] {caller}: {message}";
+            string line = $"{DateTime.Now:HH:mm:ss.fff} [{Environment.CurrentManagedThreadId,3}] {caller}: {message}";
             lock (_lock)
             {
                 try

--- a/mRemoteNG/Config/Connections/Multiuser/RemoteConnectionsSyncronizer.cs
+++ b/mRemoteNG/Config/Connections/Multiuser/RemoteConnectionsSyncronizer.cs
@@ -15,7 +15,7 @@ namespace mRemoteNG.Config.Connections.Multiuser
     {
         private readonly System.Timers.Timer _updateTimer;
         private readonly IConnectionsUpdateChecker _updateChecker;
-        private readonly object _timerLock = new();
+        private readonly System.Threading.Lock _timerLock = new();
         private bool _disposed;
 
         public double TimerIntervalInMilliseconds

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/RemoteDesktopManager/CsvConnectionsDeserializerRdmFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/RemoteDesktopManager/CsvConnectionsDeserializerRdmFormat.cs
@@ -168,7 +168,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv.RemoteDesktopMa
                     AddChildrenRecursive(group, groupParts, parentContainer);
                 }
 
-            return string.IsNullOrEmpty(group) ? (connectionInfo, default) : (connectionInfo, group);
+            return string.IsNullOrEmpty(group) ? (connectionInfo, string.Empty) : (connectionInfo, group);
         }
 
         /// <summary>

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableSerializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableSerializer.cs
@@ -383,7 +383,9 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
 
         private static void SetPrimaryKey(DataTable dataTable)
         {
-            dataTable.PrimaryKey = new[] { dataTable.Columns["ConstantID"] };
+            DataColumn constantIdColumn = dataTable.Columns["ConstantID"]
+                                          ?? throw new InvalidOperationException("The 'ConstantID' column is missing from the connections table.");
+            dataTable.PrimaryKey = [constantIdColumn];
         }
 
         private void SerializeNodesRecursive(ConnectionInfo connectionInfo)

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -90,9 +90,9 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     innerTextLength = rootXmlElement.InnerText?.Length ?? 0;
                     if (fullFileEncryptionValue)
                     {
-                        string decryptedContent = _decryptor.Decrypt(rootXmlElement.InnerText);
+                        string? decryptedContent = _decryptor.Decrypt(rootXmlElement.InnerText ?? string.Empty);
                         decryptedLength = decryptedContent?.Length ?? 0;
-                        rootXmlElement.InnerXml = decryptedContent;
+                        rootXmlElement.InnerXml = decryptedContent ?? string.Empty;
                     }
                 }
                 long fullDecryptMs = phaseSw.ElapsedMilliseconds;

--- a/mRemoteNG/Config/Settings/Providers/PortableSettingsInitializer.cs
+++ b/mRemoteNG/Config/Settings/Providers/PortableSettingsInitializer.cs
@@ -21,7 +21,7 @@ namespace mRemoteNG.Config.Settings.Providers
             _initialized = true;
 
             _sharedProvider = new ChooseProvider();
-            _sharedProvider.Initialize(_sharedProvider.Name, null);
+            _sharedProvider.Initialize(_sharedProvider.Name, null!);
 
             WireProvider(Properties.Settings.Default);
             WireProvider(Properties.App.Default);

--- a/mRemoteNG/Connection/Protocol/PuttyBase.cs
+++ b/mRemoteNG/Connection/Protocol/PuttyBase.cs
@@ -755,7 +755,7 @@ namespace mRemoteNG.Connection.Protocol
                                 if (InterfaceControl.Info?.VaultOpenbaoSecretEngine == VaultOpenbaoSecretEngine.SSHOTP)
                                     ExternalConnectors.VO.VaultOpenbao.ReadOtpSSH($"{InterfaceControl.Info?.VaultOpenbaoMount}", $"{InterfaceControl.Info?.VaultOpenbaoRole}", $"{InterfaceControl.Info?.Username}", $"{InterfaceControl.Info?.Hostname}", out password);
                                 else
-                                    ExternalConnectors.VO.VaultOpenbao.ReadPasswordSSH((int)InterfaceControl.Info?.VaultOpenbaoSecretEngine, InterfaceControl.Info?.VaultOpenbaoMount ?? "", InterfaceControl.Info?.VaultOpenbaoRole ?? "", InterfaceControl.Info?.Username ?? "root", out password);
+                                    ExternalConnectors.VO.VaultOpenbao.ReadPasswordSSH((int)InterfaceControl.Info!.VaultOpenbaoSecretEngine, InterfaceControl.Info?.VaultOpenbaoMount ?? "", InterfaceControl.Info?.VaultOpenbaoRole ?? "", InterfaceControl.Info?.Username ?? "root", out password);
                             } catch (ExternalConnectors.VO.VaultOpenbaoException ex) {
                                 Event_ErrorOccured(this, "Secret Server Interface Error: " + ex.Message, 0);
                             }

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol8.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol8.cs
@@ -261,7 +261,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
             // SmartSize handles smooth scaling during intermediate resize states.
 
             Runtime.MessageCollector.AddMessage(MessageClass.DebugMsg,
-                $"Resizing RDP connection to host '{connectionInfo.Hostname}' (SmartSize={SmartSize})");
+                $"Resizing RDP connection to host '{connectionInfo?.Hostname}' (SmartSize={SmartSize})");
 
             try
             {

--- a/mRemoteNG/Connection/Protocol/VNC/VncDesHelper.cs
+++ b/mRemoteNG/Connection/Protocol/VNC/VncDesHelper.cs
@@ -67,8 +67,9 @@ namespace mRemoteNG.Connection.Protocol.VNC
             }
             finally
             {
-                if (hKey != 0) BCryptDestroyKey(hKey);
-                if (hAlg != 0) BCryptCloseAlgorithmProvider(hAlg, 0);
+                // Cleanup status is intentionally ignored — nothing actionable can be done in a finally block.
+                if (hKey != 0) _ = BCryptDestroyKey(hKey);
+                if (hAlg != 0) _ = BCryptCloseAlgorithmProvider(hAlg, 0);
             }
         }
 

--- a/mRemoteNG/Credential/PlaceholderCredentialRecord.cs
+++ b/mRemoteNG/Credential/PlaceholderCredentialRecord.cs
@@ -11,7 +11,11 @@ namespace mRemoteNG.Credential
     [SupportedOSPlatform("windows")]
     public class PlaceholderCredentialRecord(IEnumerable<Guid> id) : ICredentialRecord
     {
+        // Placeholder records are immutable stand-ins for unavailable credentials,
+        // so this ICredentialRecord event is never raised.
+#pragma warning disable CS0067
         public event PropertyChangedEventHandler? PropertyChanged;
+#pragma warning restore CS0067
 
         public Guid Id { get; } = id.FirstOrDefault();
 

--- a/mRemoteNG/Security/KeyDerivation/Pkcs5S2KeyGenerator.cs
+++ b/mRemoteNG/Security/KeyDerivation/Pkcs5S2KeyGenerator.cs
@@ -29,8 +29,7 @@ namespace mRemoteNG.Security.KeyDerivation
                 // Use .NET native PBKDF2-HMAC-SHA1 (CNG-accelerated) instead of
                 // BouncyCastle's managed Pkcs5S2ParametersGenerator.
                 // Output is identical (RFC 2898) but ~5x faster at high iteration counts.
-                using Rfc2898DeriveBytes kdf = new(passwordInBytes, salt, _iterations, HashAlgorithmName.SHA1);
-                return kdf.GetBytes(keyLengthBytes);
+                return Rfc2898DeriveBytes.Pbkdf2(passwordInBytes, salt, _iterations, HashAlgorithmName.SHA1, keyLengthBytes);
             }
             finally
             {

--- a/mRemoteNG/Tools/MiscTools.cs
+++ b/mRemoteNG/Tools/MiscTools.cs
@@ -192,7 +192,7 @@ namespace mRemoteNG.Tools
                 return dna?.Description ?? value.ToString() ?? string.Empty;
             }
 
-            public override bool CanConvertFrom(ITypeDescriptorContext? context, Type? sourceType)
+            public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
             {
                 return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
             }

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistryRead.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistryRead.cs
@@ -18,7 +18,7 @@ namespace mRemoteNG.Tools.WindowsRegistry
         /// <summary>
         /// Gets the value of a registry entry specified by its name.
         /// </summary>
-        string GetValue(RegistryHive hive, string path, string name);
+        string? GetValue(RegistryHive hive, string path, string? name);
 
         /// <summary>
         /// Gets the string value of a registry entry specified by its name.

--- a/mRemoteNG/UI/Controls/Adapters/CredentialRecordListAdaptor.cs
+++ b/mRemoteNG/UI/Controls/Adapters/CredentialRecordListAdaptor.cs
@@ -42,7 +42,7 @@ namespace mRemoteNG.UI.Controls.Adapters
             return listBox.SelectedItem ?? value;
         }
 
-        private void ListBoxOnSelectedValueChanged([NotNull] object? sender, EventArgs eventArgs)
+        private void ListBoxOnSelectedValueChanged(object? sender, EventArgs eventArgs)
         {
             _editorService?.CloseDropDown();
         }

--- a/mRemoteNG/UI/Controls/mrngIpTextBox.cs
+++ b/mRemoteNG/UI/Controls/mrngIpTextBox.cs
@@ -47,6 +47,7 @@ namespace mRemoteNG.UI.Controls
         }
 
         /* Set or Get the string that represents the value in the box */
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public override string Text
         {
             get => (Octet1.Text ?? string.Empty) + @"." + (Octet2.Text ?? string.Empty) + @"." + (Octet3.Text ?? string.Empty) + @"." + (Octet4.Text ?? string.Empty);

--- a/mRemoteNG/UI/Forms/OptionsPages/BackupPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/BackupPage.cs
@@ -15,7 +15,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
     [SupportedOSPlatform("windows")]
     public sealed partial class BackupPage
     {
-        private FrmMain? _frmMain;
         private List<DropdownList> _permissionsListing = new List<DropdownList>();
 
         public BackupPage()

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -1557,9 +1557,10 @@ namespace mRemoteNG.UI.Forms
                 for (Control? c = ctrl; c != null; c = c.Parent)
                     if (c is ConfigWindow) return true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // ignore — best-effort guard
+                // best-effort guard — a failed hit-test must never break input handling
+                DevLog.Write($"IsCursorOverConfigWindow failed: {ex.Message}");
             }
             return false;
         }
@@ -1689,7 +1690,7 @@ namespace mRemoteNG.UI.Forms
                 {
                     var asm = System.Reflection.Assembly.GetExecutingAssembly().Location;
                     if (!string.IsNullOrEmpty(asm))
-                        titleBuilder.Append($" [DEV {System.IO.File.GetLastWriteTime(asm):HH:mm}]");
+                        titleBuilder.Append(CultureInfo.CurrentCulture, $" [DEV {System.IO.File.GetLastWriteTime(asm):HH:mm}]");
                     else
                         titleBuilder.Append(" [DEV]");
                 }
@@ -1912,8 +1913,6 @@ namespace mRemoteNG.UI.Forms
                 _clipboardChangedEvent =
                     (ClipboardchangeEventHandler?)Delegate.Remove(_clipboardChangedEvent, value);
         }
-
-        public event EventHandler? UserInterfaceResize;
 
         #endregion
 

--- a/mRemoteNG/UI/TaskDialog/CommandButton.cs
+++ b/mRemoteNG/UI/TaskDialog/CommandButton.cs
@@ -40,7 +40,8 @@ namespace mRemoteNG.UI.TaskDialog
 
         //--------------------------------------------------------------------------------
         // Override this to make sure the control is invalidated (repainted) when 'Text' is changed
-        public override string? Text
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        public override string Text
         {
             get => base.Text;
             set

--- a/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Json/JsonConnectionsSerializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Json/JsonConnectionsSerializerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System;
 using System.Linq;
 using mRemoteNG.Config.Serializers.ConnectionSerializers.Json;
 using mRemoteNG.Connection;

--- a/mRemoteNGTests/Config/Serializers/MiscSerializers/MicrosoftRdClientBackupDeserializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/MiscSerializers/MicrosoftRdClientBackupDeserializerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using mRemoteNG.Config.Serializers.MiscSerializers;
 using mRemoteNG.Connection;
@@ -82,14 +83,14 @@ public class MicrosoftRdClientBackupDeserializerTests
     public void ConnectionWithoutGroupGoesToRoot()
     {
         var rootChildren = _connectionTreeModel.RootNodes.First().Children.OfType<ConnectionInfo>().ToList();
-        Assert.That(rootChildren.Any(c => c.Name == "Server 2"), Is.True);
+        Assert.That(rootChildren.Any(c => string.Equals(c.Name, "Server 2", StringComparison.Ordinal)), Is.True);
     }
 
     [Test]
     public void ConnectionWithoutCredentialsHasEmptyUsername()
     {
         var rootChildren = _connectionTreeModel.RootNodes.First().Children.OfType<ConnectionInfo>().ToList();
-        var server2 = rootChildren.First(c => c.Name == "Server 2");
+        var server2 = rootChildren.First(c => string.Equals(c.Name, "Server 2", StringComparison.Ordinal));
         Assert.That(server2.Username, Is.EqualTo(""));
     }
 

--- a/mRemoteNGTests/Config/Serializers/MiscSerializers/MobaXTermSessionDeserializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/MiscSerializers/MobaXTermSessionDeserializerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using mRemoteNG.Config.Serializers.MiscSerializers;
 using mRemoteNG.Connection;
@@ -40,7 +41,7 @@ public class MobaXTermSessionDeserializerTests
     public void DeserializesRdpSession()
     {
         var servers = _connectionTreeModel.RootNodes.First().Children.OfType<ContainerInfo>().First();
-        var rdp = servers.Children.OfType<ConnectionInfo>().First(c => c.Name == "RDP Server");
+        var rdp = servers.Children.OfType<ConnectionInfo>().First(c => string.Equals(c.Name, "RDP Server", StringComparison.Ordinal));
         Assert.That(rdp.Hostname, Is.EqualTo("rdphost.example.com"));
         Assert.That(rdp.Port, Is.EqualTo(3389));
         Assert.That(rdp.Username, Is.EqualTo("admin"));
@@ -51,7 +52,7 @@ public class MobaXTermSessionDeserializerTests
     public void DeserializesSshSession()
     {
         var servers = _connectionTreeModel.RootNodes.First().Children.OfType<ContainerInfo>().First();
-        var ssh = servers.Children.OfType<ConnectionInfo>().First(c => c.Name == "SSH Server");
+        var ssh = servers.Children.OfType<ConnectionInfo>().First(c => string.Equals(c.Name, "SSH Server", StringComparison.Ordinal));
         Assert.That(ssh.Hostname, Is.EqualTo("sshhost.example.com"));
         Assert.That(ssh.Port, Is.EqualTo(22));
         Assert.That(ssh.Username, Is.EqualTo("root"));
@@ -62,7 +63,7 @@ public class MobaXTermSessionDeserializerTests
     public void DeserializesVncSession()
     {
         var servers = _connectionTreeModel.RootNodes.First().Children.OfType<ContainerInfo>().First();
-        var vnc = servers.Children.OfType<ConnectionInfo>().First(c => c.Name == "VNC Server");
+        var vnc = servers.Children.OfType<ConnectionInfo>().First(c => string.Equals(c.Name, "VNC Server", StringComparison.Ordinal));
         Assert.That(vnc.Hostname, Is.EqualTo("vnchost.example.com"));
         Assert.That(vnc.Port, Is.EqualTo(5900));
         Assert.That(vnc.Protocol, Is.EqualTo(ProtocolType.VNC));
@@ -72,7 +73,7 @@ public class MobaXTermSessionDeserializerTests
     public void DeserializesTelnetSession()
     {
         var network = _connectionTreeModel.RootNodes.First().Children.OfType<ContainerInfo>().Last();
-        var telnet = network.Children.OfType<ConnectionInfo>().First(c => c.Name == "Telnet Switch");
+        var telnet = network.Children.OfType<ConnectionInfo>().First(c => string.Equals(c.Name, "Telnet Switch", StringComparison.Ordinal));
         Assert.That(telnet.Hostname, Is.EqualTo("switch.example.com"));
         Assert.That(telnet.Port, Is.EqualTo(23));
         Assert.That(telnet.Username, Is.EqualTo("netadmin"));
@@ -83,7 +84,7 @@ public class MobaXTermSessionDeserializerTests
     public void HandlesUnknownProtocolDefaultsToRdp()
     {
         var network = _connectionTreeModel.RootNodes.First().Children.OfType<ContainerInfo>().Last();
-        var unknown = network.Children.OfType<ConnectionInfo>().First(c => c.Name == "Unknown Proto");
+        var unknown = network.Children.OfType<ConnectionInfo>().First(c => string.Equals(c.Name, "Unknown Proto", StringComparison.Ordinal));
         Assert.That(unknown.Protocol, Is.EqualTo(ProtocolType.RDP));
     }
 
@@ -101,7 +102,7 @@ public class MobaXTermSessionDeserializerTests
         const string content = "[Bookmarks]\nSubRep=\nImgNum=42\nMyServer=#91#host.test%3389%user%%%0%0%0\n";
         var result = new MobaXTermSessionDeserializer().Deserialize(content);
         var root = result.RootNodes.First();
-        var conn = root.Children.OfType<ConnectionInfo>().FirstOrDefault(c => c.Name == "MyServer");
+        var conn = root.Children.OfType<ConnectionInfo>().FirstOrDefault(c => string.Equals(c.Name, "MyServer", StringComparison.Ordinal));
         Assert.That(conn, Is.Not.Null);
         Assert.That(conn.Hostname, Is.EqualTo("host.test"));
     }

--- a/mRemoteNGTests/mRemoteNGTests.csproj
+++ b/mRemoteNGTests/mRemoteNGTests.csproj
@@ -3,11 +3,15 @@
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>preview</LangVersion>
+    <!-- Annotations-only: allows `T?` in test code without enabling nullable flow analysis warnings. -->
+    <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>
     <Platforms>x86;x64;arm64</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Debug;Release;Debug Portable;Release Portable;Release Installer;Deploy to github</Configurations>
-    <SupportedOSPlatformVersion>10.0.26100.0</SupportedOSPlatformVersion>
+    <!-- Must not exceed mRemoteNG.csproj's minimum, or the test host refuses to run on
+         any OS older than this (e.g. Windows 11 23H2 / 10.0.22631). -->
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Clears every compiler and analyzer warning in the solution (the build now reports **0 warnings**) and fixes a test-project setting that made the suite unrunnable on any OS older than Windows 11 24H2.

## Commits

1. **`chore(tests)`** — `string.Equals(..., StringComparison.Ordinal)` for MA0006; duplicate `using System;` removed (CS0105).
2. **`fix(build)`** — nullability, analyzer and dead-code fixes across mRemoteNG. See the commit body for the per-warning rationale.
3. **`chore(deps)`** — drops the `System.DirectoryServices` PackageReference (NU1510); the framework supplies it and no source uses the namespace. The forced recompile surfaced an unused designer field (CS0169).
4. **`chore(tests)`** — lowers `SupportedOSPlatformVersion` from 10.0.26100.0 to 10.0.17763.0, and sets `Nullable=annotations`.

## Notable decisions

- **`Pkcs5S2KeyGenerator`** now calls the static `Rfc2898DeriveBytes.Pbkdf2` overload, clearing SYSLIB0060 and CA5379. **SHA1 is retained deliberately** — it is required to decrypt existing connection files. Derived bytes are unchanged. This is the change most worth a careful review, since it sits on the key-derivation path for every stored password.
- **`SupportedOSPlatformVersion`**: the test project was pinned *stricter than the app it tests* (26100 vs the app's 17763). The test host therefore reported `Only supported on Windows10.0.26100.0` and executed **zero** tests on Windows 11 23H2. Aligning it with mRemoteNG.csproj produces no CA1416 warnings. CI on `windows-2025-vs2026` is unaffected.
- **`Nullable=annotations`** rather than per-file `#nullable enable` pragmas: it enables the annotation context without turning on flow-analysis warnings across a ~6.3k-test project.
- **`PlaceholderCredentialRecord.PropertyChanged`** uses a scoped `#pragma warning disable CS0067` instead of no-op `add`/`remove` accessors, so the event still behaves normally if the type ever starts raising it.

## Verification

- Full build via `build.ps1`: exit 0, **0 warnings**, 0 errors.
- Test suite: **6,339 / 6,341 passing**.

## Known failure, pre-existing

`ConnectionsServiceStartupPathTests.StartupConnectionPathReturnsSavedPathWhenItIsTheSoleCandidate` fails on my dev box. It calls `GetStartupConnectionFileName` via reflection, which performs live filesystem discovery; discovery finds a candidate beside the test binaries and prefers it over the injected temp path. The test's own comment anticipates this scenario, but the assertion is stricter than the comment.

None of the files touched here are on that code path — `ConnectionsService` and `ConnectionsFileResolver` are untouched, and the one settings-adjacent edit (`null` → `null!`) is annotation-only with identical IL. **Caveat:** I have no local baseline, because the suite could not run on this machine before commit 4.

Relatedly, the parallel group runner reports 2 failures where a single-process run reports 1 — the extra one is order-dependent, as this test mutates the static `OptionsConnectionsPage.Default` singleton.