### PR TITLE
chore(deps): drop redundant direct ZstdSharp.Port references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,6 +68,7 @@
     <PackageVersion Include="System.Windows.Extensions" Version="10.0.5" />
     <PackageVersion Include="VaultSharp" Version="1.17.5.1" />
     <PackageVersion Include="VncSharpCore" Version="1.2.1" />
+    <!-- Transitive via MySql.Data (floor 0.8.6); pinned here to 0.8.7 by central transitive pinning. -->
     <PackageVersion Include="ZstdSharp.Port" Version="0.8.7" />
   </ItemGroup>
 </Project>

--- a/mRemoteNG/mRemoteNG.csproj
+++ b/mRemoteNG/mRemoteNG.csproj
@@ -250,7 +250,6 @@
     <PackageReference Include="System.Management" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" />
     <PackageReference Include="VncSharpCore" />
-    <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Language\Language.Designer.cs">

--- a/mRemoteNGSpecs/mRemoteNGSpecs.csproj
+++ b/mRemoteNGSpecs/mRemoteNGSpecs.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="SpecFlow" />
     <PackageReference Include="SpecFlow.NUnit" />
-    <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\mRemoteNG\mRemoteNG.csproj" />

--- a/mRemoteNGTests/mRemoteNGTests.csproj
+++ b/mRemoteNGTests/mRemoteNGTests.csproj
@@ -29,7 +29,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Data.Odbc" />
-    <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\mRemoteNG\mRemoteNG.csproj" />


### PR DESCRIPTION
## What

Removes the direct `ZstdSharp.Port` `PackageReference` from `mRemoteNG`, `mRemoteNGTests`, and `mRemoteNGSpecs`.

## Why

No project code references `ZstdSharp` — the package arrives transitively via `MySql.Data`, whose nuspec declares `ZstdSharp.Port >= 0.8.6` on every target framework (used for MySQL protocol zstd compression). The three direct references added nothing.

## The one thing worth reviewing

The central `PackageVersion` for `ZstdSharp.Port` is **deliberately kept at 0.8.7**. With `CentralPackageTransitivePinningEnabled=true`, that entry is what bumps the resolved version above `MySql.Data`'s 0.8.6 floor. Deleting it alongside the `PackageReference` lines would silently downgrade the shipped assembly to 0.8.6 — so this PR keeps it, plus a comment explaining why the entry has no matching `PackageReference`.

## Verification

Full build via `build.ps1` (VS2026 MSBuild 18.x), green. After the change:

- `mRemoteNG/obj/project.assets.json` → `ZstdSharp.Port/0.8.7`
- `mRemoteNG/bin/x64/Release/mRemoteNG.deps.json` → `ZstdSharp.Port/0.8.7`
- `mRemoteNG/bin/x64/Release/Assemblies/ZstdSharp.dll` still present

No behavior change — same assembly, same version, one less redundant declaration in three project files.
