### PR TITLE
fix: apply the colour picked in the property grid Color/TabColor fields

### DIFF
--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -214,7 +214,7 @@ namespace mRemoteNG.Connection
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Display)),
          LocalizedAttributes.LocalizedDisplayName(nameof(Language.Color)),
          LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionColor)),
-         Editor(typeof(System.Drawing.Design.ColorEditor), typeof(System.Drawing.Design.UITypeEditor)),
+         Editor(typeof(UI.Controls.ConnectionInfoPropertyGrid.ColorStringEditor), typeof(System.Drawing.Design.UITypeEditor)),
          TypeConverter(typeof(MiscTools.TabColorConverter))]
         public virtual string Color
         {
@@ -225,7 +225,7 @@ namespace mRemoteNG.Connection
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Display)),
          LocalizedAttributes.LocalizedDisplayName(nameof(Language.TabColor)),
          LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionTabColor)),
-         Editor(typeof(System.Drawing.Design.ColorEditor), typeof(System.Drawing.Design.UITypeEditor)),
+         Editor(typeof(UI.Controls.ConnectionInfoPropertyGrid.ColorStringEditor), typeof(System.Drawing.Design.UITypeEditor)),
          TypeConverter(typeof(MiscTools.TabColorConverter))]
         public virtual string TabColor
         {

--- a/mRemoteNG/Tools/MiscTools.cs
+++ b/mRemoteNG/Tools/MiscTools.cs
@@ -387,6 +387,12 @@ namespace mRemoteNG.Tools
 
                 if (value is Color colorValue)
                 {
+                    // An empty color means "no color set" and must stay an empty string.
+                    if (colorValue.IsEmpty)
+                    {
+                        return string.Empty;
+                    }
+
                     // Convert Color to string representation
                     // Use named color if it's a known color, otherwise use hex format
                     if (colorValue.IsNamedColor)
@@ -452,7 +458,9 @@ namespace mRemoteNG.Tools
 
             public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context)
             {
-                // Provide a list of common colors for the dropdown
+                // Provide a list of common colors for the dropdown. The values must be
+                // strings: the annotated properties are strings, and the grid commits the
+                // picked standard value without running it through this converter.
                 Color[] colors =
                 [
                     Color.Red,
@@ -477,7 +485,7 @@ namespace mRemoteNG.Tools
                     Color.Olive
                 ];
 
-                return new StandardValuesCollection(colors);
+                return new StandardValuesCollection(Array.ConvertAll(colors, color => color.Name));
             }
 
             public override bool GetStandardValuesExclusive(ITypeDescriptorContext? context)

--- a/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ColorStringEditor.cs
+++ b/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ColorStringEditor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Design;
+using mRemoteNG.Tools;
+
+namespace mRemoteNG.UI.Controls.ConnectionInfoPropertyGrid
+{
+    /// <summary>
+    /// Color picker for properties that are stored as a string. The stock
+    /// <see cref="ColorEditor"/> hands a <see cref="Color"/> straight to
+    /// <see cref="PropertyDescriptor.SetValue"/>, which fails with
+    /// "Property value is not valid" on a string property, so the value is
+    /// translated in both directions here.
+    /// </summary>
+    public class ColorStringEditor : ColorEditor
+    {
+        private static readonly MiscTools.TabColorConverter Converter = new();
+
+        public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
+        {
+            object? editedValue = base.EditValue(context, provider, ToColor(value));
+            return editedValue is Color color ? Converter.ConvertFrom(color) : value;
+        }
+
+        public override void PaintValue(PaintValueEventArgs e)
+        {
+            base.PaintValue(new PaintValueEventArgs(e.Context, ToColor(e.Value), e.Graphics, e.Bounds));
+        }
+
+        private static object? ToColor(object? value)
+        {
+            if (value is Color)
+                return value;
+
+            try
+            {
+                return Converter.ConvertTo(null, null, value, typeof(Color));
+            }
+            catch (NotSupportedException)
+            {
+                return Color.Empty;
+            }
+        }
+    }
+}

--- a/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ColorStringEditor.cs
+++ b/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ColorStringEditor.cs
@@ -19,28 +19,59 @@ namespace mRemoteNG.UI.Controls.ConnectionInfoPropertyGrid
 
         public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
         {
-            object? editedValue = base.EditValue(context, provider, ToColor(value));
-            return editedValue is Color color ? Converter.ConvertFrom(color) : value;
+            bool valueIsAColor = TryConvertToColor(value, out Color currentColor);
+            object? editedValue = base.EditValue(context, provider, currentColor);
+
+            if (editedValue is not Color pickedColor)
+                return value;
+
+            // A value the converter cannot parse - a legacy or hand-edited entry, say -
+            // also arrives here as an empty color. Dismissing the picker would then wipe
+            // it, so it is kept until a real color is picked.
+            if (pickedColor.IsEmpty && !valueIsAColor)
+                return value;
+
+            return Converter.ConvertFrom(pickedColor);
         }
 
         public override void PaintValue(PaintValueEventArgs e)
         {
-            base.PaintValue(new PaintValueEventArgs(e.Context, ToColor(e.Value), e.Graphics, e.Bounds));
+            TryConvertToColor(e.Value, out Color color);
+            base.PaintValue(new PaintValueEventArgs(e.Context, color, e.Graphics, e.Bounds));
         }
 
-        private static object? ToColor(object? value)
+        /// <summary>
+        /// Converts a stored value to the <see cref="Color"/> the wrapped editor works
+        /// with, reporting whether it actually describes a color.
+        /// </summary>
+        private static bool TryConvertToColor(object? value, out Color color)
         {
-            if (value is Color)
-                return value;
+            color = Color.Empty;
+
+            if (value is Color existingColor)
+            {
+                color = existingColor;
+                return true;
+            }
+
+            // Nothing stored means "no color", which is a valid state rather than a
+            // failed conversion.
+            if (value is null || (value is string text && string.IsNullOrWhiteSpace(text)))
+                return true;
 
             try
             {
-                return Converter.ConvertTo(null, null, value, typeof(Color));
+                if (Converter.ConvertTo(null, null, value, typeof(Color)) is Color convertedColor)
+                    color = convertedColor;
             }
             catch (NotSupportedException)
             {
-                return Color.Empty;
+                return false;
             }
+
+            // TabColorConverter maps text it cannot parse to an empty color instead of
+            // throwing, so an empty result here means the conversion failed.
+            return !color.IsEmpty;
         }
     }
 }

--- a/mRemoteNGTests/Tools/TabColorConverterTests.cs
+++ b/mRemoteNGTests/Tools/TabColorConverterTests.cs
@@ -56,6 +56,13 @@ namespace mRemoteNGTests.Tools
         }
 
         [Test]
+        public void ConvertFromEmptyColorReturnsEmptyString()
+        {
+            var result = _converter.ConvertFrom(Color.Empty);
+            Assert.That(result, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
         public void ConvertFromStringReturnsString()
         {
             var colorString = "Blue";

--- a/mRemoteNGTests/UI/Controls/ColorStringEditorTests.cs
+++ b/mRemoteNGTests/UI/Controls/ColorStringEditorTests.cs
@@ -40,6 +40,15 @@ namespace mRemoteNGTests.UI.Controls
             Assert.That(result, Is.EqualTo(value));
         }
 
+        [TestCase("not-a-color")]
+        [TestCase("#nothex")]
+        public void EditValueKeepsAValueItCannotParse(string value)
+        {
+            // Dismissing the picker must not discard a legacy or hand-edited entry.
+            var result = _editor.EditValue(null, new EmptyServiceProvider(), value);
+            Assert.That(result, Is.EqualTo(value));
+        }
+
         [Test]
         public void EditValueOfNullDoesNotThrow()
         {

--- a/mRemoteNGTests/UI/Controls/ColorStringEditorTests.cs
+++ b/mRemoteNGTests/UI/Controls/ColorStringEditorTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Design;
+using System.Linq;
+using mRemoteNG.Connection;
+using mRemoteNG.Tools;
+using mRemoteNG.UI.Controls.ConnectionInfoPropertyGrid;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.UI.Controls
+{
+    [NUnit.Framework.Apartment(System.Threading.ApartmentState.STA)]
+    public class ColorStringEditorTests
+    {
+        private ColorStringEditor _editor;
+
+        /// <summary>
+        /// Without an <see cref="System.Windows.Forms.Design.IWindowsFormsEditorService"/>
+        /// the base <see cref="ColorEditor"/> shows no dialog and echoes the value it was
+        /// given, which exercises the round trip without any UI.
+        /// </summary>
+        private sealed class EmptyServiceProvider : IServiceProvider
+        {
+            public object? GetService(Type serviceType) => null;
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _editor = new ColorStringEditor();
+        }
+
+        [TestCase("Red")]
+        [TestCase("#804020")]
+        [TestCase("")]
+        public void EditValueReturnsAString(string value)
+        {
+            var result = _editor.EditValue(null, new EmptyServiceProvider(), value);
+            Assert.That(result, Is.EqualTo(value));
+        }
+
+        [Test]
+        public void EditValueOfNullDoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => _editor.EditValue(null, new EmptyServiceProvider(), null));
+        }
+
+        [TestCase(nameof(ConnectionInfo.Color))]
+        [TestCase(nameof(ConnectionInfo.TabColor))]
+        public void ColorPropertiesUseTheStringAwareEditor(string propertyName)
+        {
+            var editor = TypeDescriptor.GetProperties(typeof(ConnectionInfo))[propertyName]
+                                       ?.GetEditor(typeof(UITypeEditor));
+            Assert.That(editor, Is.InstanceOf<ColorStringEditor>());
+        }
+
+        [Test]
+        public void StandardValuesAreStringsSoTheDropDownCanBeCommitted()
+        {
+            var standardValues = new MiscTools.TabColorConverter().GetStandardValues(null);
+            Assert.That(standardValues, Is.Not.Null);
+            Assert.That(standardValues.Cast<object>(), Is.All.InstanceOf<string>());
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Setting **Color** or **Tab Color** on a connection via the property-grid picker fails with `Property value is not valid` / `Object of type 'System.Drawing.Color' cannot be converted to type 'System.String'`, and the colour is never applied.

## Root cause

Both properties are `string`, but they were annotated with the stock `System.Drawing.Design.ColorEditor`, which returns a `System.Drawing.Color`. The PropertyGrid commits an editor's return value straight through `PropertyDescriptor.SetValue` and never runs the `TypeConverter` on that path, so the assignment throws.

`MiscTools.TabColorConverter` already handled `Color` → `string`, but only the text-entry path goes through it — which is why the error survived that earlier fix.

## Changes

- **`ColorStringEditor`** (new) — wraps `ColorEditor` for string-backed colour properties: feeds the editor a `Color`, translates the picked colour back into the stored string form. Also restores the swatch preview, which was blank because `ColorEditor` cannot paint a string value.
- `AbstractConnectionRecord.Color` / `.TabColor` now use the new editor.
- `TabColorConverter.GetStandardValues` returns strings instead of `Color` objects — picking an entry from the dropdown list failed in exactly the same way.
- `TabColorConverter.ConvertFrom(Color.Empty)` now yields `""` instead of `"#00000000"`, so clearing a colour leaves the property unset.

## Verification

Full MSBuild build succeeds.

Note for reviewers: the NUnit suite could not be executed on my machine — every group reports `NUnit couldn't run the N discovered tests: Only supported on Windows10.0.26100.0`, because `mRemoteNGTests.csproj` sets `SupportedOSPlatformVersion 10.0.26100.0` while the host is Windows 10.0.22631. That block is pre-existing and assembly-wide (it hits untouched groups such as Config and Security identically) and unrelated to this change, so I left the test project's target platform alone. CI should run the suite normally.

To verify behaviour regardless, I ran the equivalent assertions against the built `mRemoteNG.dll` from a standalone harness — all pass:

- string round-trip through the editor for `"Red"`, `"#804020"`, `""` and `null`
- both properties resolve to `ColorStringEditor`
- `SetValue` with the editor's output stores `"Purple"` instead of throwing
- standard values are all strings

New tests added: `mRemoteNGTests/UI/Controls/ColorStringEditorTests.cs` (non-interactive — no `IWindowsFormsEditorService` is supplied, so no dialog is shown) plus an empty-colour case in `TabColorConverterTests`.
