### PR TITLE
fix: keep the active tab when a tab close is cancelled

### DIFF
--- a/mRemoteNG/UI/Tabs/DockPaneStripNG.cs
+++ b/mRemoteNG/UI/Tabs/DockPaneStripNG.cs
@@ -1385,7 +1385,7 @@ namespace mRemoteNG.UI.Tabs
 
                         try
                         {
-                            TryCloseTab(i);
+                            CloseTab(i);
                         }
                         catch (NullReferenceException)
                         {
@@ -1411,6 +1411,34 @@ namespace mRemoteNG.UI.Tabs
             catch (InvalidOperationException)
             {
                 _ = 0; // Intentionally empty — control may be disposed
+            }
+        }
+
+        /// <summary>
+        /// Closes the tab at <paramref name="index"/>, keeping the current selection when
+        /// the tab does not actually close.
+        /// </summary>
+        /// <remarks>
+        /// DockPanelSuite's TryCloseTab selects the neighbouring tab afterwards without
+        /// checking whether the close happened, so dismissing the "are you sure" prompt
+        /// still switched the active connection.
+        /// </remarks>
+        private void CloseTab(int index)
+        {
+            IDockContent tabContent = Tabs[index].Content;
+            IDockContent? activeBeforeClose = DockPane.ActiveContent;
+
+            TryCloseTab(index);
+
+            if (activeBeforeClose == null || ReferenceEquals(DockPane.ActiveContent, activeBeforeClose))
+                return;
+
+            // The tab is still on display, so the close was refused and the selection
+            // moved for nothing.
+            if (DockPane.DisplayingContents.Contains(tabContent) &&
+                DockPane.DisplayingContents.Contains(activeBeforeClose))
+            {
+                activeBeforeClose.DockHandler.Activate();
             }
         }
 

--- a/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
+++ b/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
@@ -15,28 +15,77 @@ namespace mRemoteNGTests.UI.Tabs
     [TestFixture]
     public class DockPaneStripNGTests
     {
+        private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// Runs <paramref name="testAction"/> on an STA thread with a real message loop, so
+        /// docking layout work that relies on posted messages completes.
+        /// </summary>
         private static void RunWithMessagePump(Action testAction)
         {
-            Exception? caught = null;
+            Exception caught = null;
+            Form pump = null;
+            using var pumpReady = new ManualResetEventSlim(false);
+
             var thread = new Thread(() =>
             {
-                try
+                pump = new Form
                 {
-                    testAction();
-                }
-                catch (Exception ex)
+                    ShowInTaskbar = false,
+                    StartPosition = FormStartPosition.Manual,
+                    Location = new System.Drawing.Point(-10000, -10000)
+                };
+
+                _ = pump.Handle; // Force handle creation so the loop below can be posted to.
+                pumpReady.Set();
+
+                // Action, not MethodInvoker: this file imports System.Reflection, which also
+                // has a MethodInvoker on .NET 8+.
+                pump.BeginInvoke(new Action(() =>
                 {
-                    caught = ex;
-                }
-            });
+                    try
+                    {
+                        testAction();
+                    }
+                    catch (Exception ex)
+                    {
+                        caught = ex;
+                    }
+                    finally
+                    {
+                        Application.ExitThread();
+                    }
+                }));
+
+                Application.Run(new ApplicationContext());
+                pump.Dispose();
+            })
+            {
+                // Last-resort safety net: a wedged UI thread must never hold the test run open.
+                IsBackground = true
+            };
 
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
+            pumpReady.Wait(ShutdownTimeout);
 
-            if (!thread.Join(TimeSpan.FromSeconds(30)))
+            if (!thread.Join(TestTimeout))
             {
-                thread.Interrupt();
-                Assert.Fail("Test timed out after 30 seconds");
+                // Ask the loop to unwind. This only lands if the thread is still pumping;
+                // when it is not, IsBackground keeps the timeout from hanging the run.
+                try
+                {
+                    pump?.BeginInvoke(new Action(Application.ExitThread));
+                }
+                catch (InvalidOperationException)
+                {
+                    // Handle was never created, or the form was disposed as the loop
+                    // unwound (ObjectDisposedException derives from this).
+                }
+
+                thread.Join(ShutdownTimeout);
+                Assert.Fail($"Test timed out after {TestTimeout.TotalSeconds} seconds");
             }
 
             if (caught != null)

--- a/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
+++ b/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
@@ -110,6 +110,71 @@ namespace mRemoteNGTests.UI.Tabs
         });
 
         [Test]
+        public void CancellingATabClose_LeavesTheActiveTabUnchanged() => RunWithMessagePump(() =>
+        {
+            // Arrange
+            using var hostForm = new Form
+            {
+                Width = 800,
+                Height = 600,
+                ShowInTaskbar = false,
+                StartPosition = FormStartPosition.Manual,
+                Location = new System.Drawing.Point(-10000, -10000)
+            };
+
+            var dockPanel = new DockPanel
+            {
+                Dock = DockStyle.Fill,
+                DocumentStyle = DocumentStyle.DockingWindow,
+                Theme = new VS2015LightTheme()
+            };
+
+            dockPanel.Theme.Extender.DockPaneStripFactory = new MremoteDockPaneStripFactory();
+
+            hostForm.Controls.Add(dockPanel);
+            hostForm.Show();
+
+            var doc1 = new DockContent { Text = "Doc1", CloseButton = true, CloseButtonVisible = true };
+            var doc2 = new DockContent { Text = "Doc2", CloseButton = true, CloseButtonVisible = true };
+            var doc3 = new DockContent { Text = "Doc3", CloseButton = true, CloseButtonVisible = true };
+
+            doc1.Show(dockPanel, DockState.Document);
+            doc2.Show(dockPanel, DockState.Document);
+            doc3.Show(dockPanel, DockState.Document);
+
+            Application.DoEvents();
+
+            // Stands in for the user dismissing the close confirmation. No dialog is shown,
+            // so the test stays headless.
+            doc2.FormClosing += (_, e) => e.Cancel = true;
+
+            doc2.DockHandler.Activate();
+            Application.DoEvents();
+            Assert.That(doc2.DockHandler.Pane.ActiveContent, Is.SameAs(doc2), "Doc2 should start out active");
+
+            Control dockPaneStrip = FindDockPaneStripNG(dockPanel);
+            Assert.That(dockPaneStrip, Is.Not.Null, "Could not find DockPaneStripNG control");
+
+            MethodInfo middleClickMethod = dockPaneStrip.GetType().GetMethod("MiddleClickCloseTab", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(middleClickMethod, Is.Not.Null, "Could not find MiddleClickCloseTab method");
+
+            // Act - close Doc2, which is not the first tab, so DockPanelSuite would otherwise
+            // select Doc1 once the close attempt returns.
+            middleClickMethod.Invoke(dockPaneStrip, new object[] { 1 });
+
+            DateTime start = DateTime.Now;
+            while ((DateTime.Now - start).TotalSeconds < 2)
+            {
+                Application.DoEvents();
+                Thread.Sleep(10);
+            }
+
+            // Assert
+            Assert.That(doc2.DockState, Is.EqualTo(DockState.Document), "Doc2 should still be open");
+            Assert.That(doc2.DockHandler.Pane.ActiveContent, Is.SameAs(doc2), "Doc2 should still be the active tab");
+        });
+
+        [Test]
         public void IsWithinUndockSuppressionZone_ReturnsTrue_WhenPointerIsJustOutsideStrip()
         {
             var tabStripBounds = new Rectangle(0, 0, 120, 24);


### PR DESCRIPTION
## Problem

Closing a connection tab shows the "are you sure you want to close" prompt. Clicking **Cancel** correctly keeps the tab open, but the active connection switches to the tab on its left.

## Root cause

Not in the confirmation logic — it is DockPanelSuite. `DockPaneStripBase.TryCloseTab`:

```csharp
DockPane.CloseContent(content);
if (PatchController.EnableSelectClosestOnClose == true)
    SelectClosestPane(index);        // DockPane.ActiveContent = Tabs[index - 1].Content
```

`SelectClosestPane` runs unconditionally — it never checks whether the close actually happened. `EnableSelectClosestOnClose` defaults to `true`, and `connDock.DocumentStyle` is `DockingWindow` whenever more than one tab is open, so both of its guards pass. When `ConnectionTab.OnFormClosing` sets `e.Cancel = true`, the tab survives but DPS has already moved the selection.

It only bites when the tab being closed is not the first one (`SelectClosestPane` is guarded by `index > 0`), which is why the bug can look intermittent.

## Fix

`DockPaneStripNG` wraps the close and puts the selection back when the tab is still on display:

```csharp
private void CloseTab(int index)
{
    IDockContent tabContent = Tabs[index].Content;
    IDockContent? activeBeforeClose = DockPane.ActiveContent;

    TryCloseTab(index);

    if (activeBeforeClose == null || ReferenceEquals(DockPane.ActiveContent, activeBeforeClose))
        return;

    if (DockPane.DisplayingContents.Contains(tabContent) &&
        DockPane.DisplayingContents.Contains(activeBeforeClose))
    {
        activeBeforeClose.DockHandler.Activate();
    }
}
```

Keying off `DisplayingContents` rather than a cancel flag covers every refusal — the confirmation prompt, a protocol veto, `KeepTabsOpenAfterDisconnect` — and it deliberately does nothing on a successful close, so the existing MRU/adjacent-tab behaviour is untouched. `Activate()` rather than a bare `ActiveContent` assignment also restores keyboard focus to the tab. Both entry points into `QueueCloseTab` (close button and middle-click) are covered.

## Verification

Solution builds clean.

The NUnit suite could not be executed on my machine — every group reports `NUnit couldn't run the N discovered tests: Only supported on Windows10.0.26100.0`, because `mRemoteNGTests.csproj` sets `SupportedOSPlatformVersion 10.0.26100.0` while the host is Windows 10.0.22631. Pre-existing and unrelated to this change; CI should run the suite normally.

Behaviour was verified by driving the real `DockPaneStripNG` from a standalone STA harness against the built assembly:

```
PASS  Doc2 starts active
PASS  cancelled close leaves Doc2 open
PASS  cancelled close keeps Doc2 active
  (control) after raw TryCloseTab, Doc2 open=True, active=Doc1
PASS  uncancelled close still closes Doc3
```

The control line is the bug reproduced directly: calling DPS's `TryCloseTab` leaves the tab open but hands the selection to `Doc1`.

New test: `DockPaneStripNGTests.CancellingATabClose_LeavesTheActiveTabUnchanged`, using a `FormClosing` handler that cancels — headless, no dialog, following the existing message-pump pattern in that fixture.
