### PR TITLE
fix: close a PuTTY tab in one step, without PuTTY's own prompt

### DIFF
--- a/mRemoteNG/App/NativeMethods.cs
+++ b/mRemoteNG/App/NativeMethods.cs
@@ -138,6 +138,9 @@ namespace mRemoteNG.App
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
         [DllImport("user32.dll", SetLastError = true)]
         internal static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
 

--- a/mRemoteNG/Connection/Protocol/PuttyBase.cs
+++ b/mRemoteNG/Connection/Protocol/PuttyBase.cs
@@ -36,6 +36,11 @@ namespace mRemoteNG.Connection.Protocol
         private const int TerminalTitlePollIntervalMs = 500;
         private const int WindowTextBufferLength = 512;
         private const int OpeningCommandPollIntervalMs = 250;
+        private const int GracefulCloseTimeoutMs = 1000;
+        private const int GracefulClosePollIntervalMs = 50;
+        private const int MessageBoxIdOk = 1;
+        private const string DialogWindowClassName = "#32770";
+        private const string PuttyExitConfirmationTitle = "Exit Confirmation";
         private bool _isPuttyNg;
         private readonly DisplayProperties _display = new();
         private readonly Lock _terminalTitleSync = new();
@@ -1174,7 +1179,83 @@ namespace mRemoteNG.Connection.Protocol
             if (!closeRequested)
                 return false;
 
-            return PuttyProcess.WaitForExit(1000);
+            // PuTTY answers WM_CLOSE with its own "Are you sure you want to close this
+            // session?" box whenever warn-on-close is enabled for the session. mRemoteNG
+            // already asked the user to confirm the disconnect, so acknowledge that box on
+            // their behalf instead of making them answer the same question twice.
+            int waitedMs = 0;
+            while (waitedMs < GracefulCloseTimeoutMs)
+            {
+                if (PuttyProcess.WaitForExit(GracefulClosePollIntervalMs))
+                    return true;
+
+                waitedMs += GracefulClosePollIntervalMs;
+                DismissPuttyExitConfirmation();
+            }
+
+            return PuttyProcess.HasExited;
+        }
+
+        private void DismissPuttyExitConfirmation()
+        {
+            IntPtr confirmationDialog = FindPuttyExitConfirmationDialog();
+            if (confirmationDialog == IntPtr.Zero)
+                return;
+
+            NativeMethods.PostMessage(confirmationDialog,
+                                      NativeMethods.WM_COMMAND,
+                                      (IntPtr)MessageBoxIdOk,
+                                      IntPtr.Zero);
+        }
+
+        private IntPtr FindPuttyExitConfirmationDialog()
+        {
+            uint puttyProcessId;
+            try
+            {
+                if (PuttyProcess == null)
+                    return IntPtr.Zero;
+
+                puttyProcessId = (uint)PuttyProcess.Id;
+            }
+            catch (InvalidOperationException)
+            {
+                return IntPtr.Zero;
+            }
+
+            IntPtr dialogHandle = IntPtr.Zero;
+
+            NativeMethods.EnumWindows((hWnd, lParam) =>
+            {
+                _ = NativeMethods.GetWindowThreadProcessId(hWnd, out uint windowProcessId);
+                if (windowProcessId != puttyProcessId)
+                    return true;
+
+                StringBuilder className = new(WindowTextBufferLength);
+                _ = NativeMethods.GetClassName(hWnd, className, className.Capacity);
+
+                StringBuilder windowTitle = new(WindowTextBufferLength);
+                _ = NativeMethods.GetWindowText(hWnd, windowTitle, windowTitle.Capacity);
+
+                if (!IsPuttyExitConfirmation(className.ToString(), windowTitle.ToString()))
+                    return true;
+
+                dialogHandle = hWnd;
+                return false;
+            }, IntPtr.Zero);
+
+            return dialogHandle;
+        }
+
+        /// <summary>
+        /// Identifies PuTTY's warn-on-close message box. Only that box may be answered
+        /// automatically - every other PuTTY dialog (host key security alert, settings)
+        /// must stay under user control.
+        /// </summary>
+        internal static bool IsPuttyExitConfirmation(string windowClassName, string windowTitle)
+        {
+            return string.Equals(windowClassName, DialogWindowClassName, StringComparison.Ordinal) &&
+                   windowTitle.Contains(PuttyExitConfirmationTitle, StringComparison.OrdinalIgnoreCase);
         }
 
         public override void Close()

--- a/mRemoteNG/UI/Tabs/ConnectionTab.cs
+++ b/mRemoteNG/UI/Tabs/ConnectionTab.cs
@@ -30,6 +30,13 @@ namespace mRemoteNG.UI.Tabs
         /// </summary>
         public bool protocolClose { get; set; }
 
+        /// <summary>
+        /// Disconnect-only close (tab context menu "Disconnect"). The tab is kept open
+        /// showing the reconnect panel when KeepTabsOpenAfterDisconnect is enabled.
+        /// Closing the tab itself always removes the tab, regardless of that option.
+        /// </summary>
+        public bool disconnectOnly { get; set; }
+
         public ConnectionInfo? TrackedConnectionInfo { get; private set; }
 
         private Label? _closedStateLabel;
@@ -227,16 +234,14 @@ namespace mRemoteNG.UI.Tabs
                         else
                         {
                             CloseProtocolSafe();
-                            // Protocol close handler (HandleProtocolClosed) will show closed state.
-                            // Cancel form close so the tab stays open with Connect button (#61).
-                            if (Properties.OptionsTabsPanelsPage.Default.KeepTabsOpenAfterDisconnect)
+                            if (KeepTabOpenAfterDisconnect)
                                 e.Cancel = true;
                         }
                     }
                     else
                     {
                         CloseProtocolSafe();
-                        if (Properties.OptionsTabsPanelsPage.Default.KeepTabsOpenAfterDisconnect)
+                        if (KeepTabOpenAfterDisconnect)
                             e.Cancel = true;
                     }
                 }
@@ -249,6 +254,14 @@ namespace mRemoteNG.UI.Tabs
 
             base.OnFormClosing(e);
         }
+
+        /// <summary>
+        /// The protocol close handler (HandleProtocolClosed) shows the closed state with a
+        /// Connect button (#61), so the form close is cancelled to keep the tab alive. This
+        /// only applies to a disconnect request - closing the tab must close the tab.
+        /// </summary>
+        private bool KeepTabOpenAfterDisconnect =>
+            disconnectOnly && Properties.OptionsTabsPanelsPage.Default.KeepTabsOpenAfterDisconnect;
 
         private void CloseProtocolSafe()
         {

--- a/mRemoteNG/UI/Window/ConnectionWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionWindow.cs
@@ -1842,6 +1842,7 @@ namespace mRemoteNG.UI.Window
                         return;
                 }
 
+                selectedTab.disconnectOnly = true;
                 selectedTab.Close();
             }
             catch (Exception ex)
@@ -2261,7 +2262,9 @@ namespace mRemoteNG.UI.Window
                 if (closedConnectionInfo != null)
                     tabPage.TrackConnection(closedConnectionInfo);
 
-                if (keepTabOpen)
+                // A tab that is already closing must not be revived with the closed state
+                // panel - the user asked for the tab itself to go away, not to disconnect.
+                if (keepTabOpen && !tabPage.Disposing)
                 {
                     if (protocolBase.InterfaceControl != null)
                     {

--- a/mRemoteNGTests/Connection/Protocol/PuttyBaseTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/PuttyBaseTests.cs
@@ -126,6 +126,22 @@ namespace mRemoteNGTests.Connection.Protocol
             Assert.That(_puttyProtocol.DeferredResizeCallCount, Is.GreaterThan(initialCount));
         }
 
+        [TestCase("PuTTY Exit Confirmation")]
+        [TestCase("PuTTYNG Exit Confirmation")]
+        public void IsPuttyExitConfirmation_MatchesTheWarnOnCloseMessageBox(string windowTitle)
+        {
+            Assert.That(PuttyBase.IsPuttyExitConfirmation("#32770", windowTitle), Is.True);
+        }
+
+        [TestCase("#32770", "PuTTY Security Alert", TestName = "IsPuttyExitConfirmation_IgnoresTheHostKeyAlert")]
+        [TestCase("#32770", "PuTTY Reconfiguration", TestName = "IsPuttyExitConfirmation_IgnoresTheSettingsDialog")]
+        [TestCase("PuTTY", "example-host - PuTTY", TestName = "IsPuttyExitConfirmation_IgnoresTheTerminalWindow")]
+        [TestCase("#32770", "", TestName = "IsPuttyExitConfirmation_IgnoresUntitledDialogs")]
+        public void IsPuttyExitConfirmation_LeavesOtherWindowsAlone(string windowClassName, string windowTitle)
+        {
+            Assert.That(PuttyBase.IsPuttyExitConfirmation(windowClassName, windowTitle), Is.False);
+        }
+
         private sealed class TestablePuttyBase : PuttyBase
         {
             private readonly Queue<string> _queuedTitles = new();

--- a/mRemoteNGTests/UI/Tabs/ConnectionTabCloseTests.cs
+++ b/mRemoteNGTests/UI/Tabs/ConnectionTabCloseTests.cs
@@ -1,0 +1,125 @@
+using System.Reflection;
+using System.Threading;
+using System.Windows.Forms;
+using mRemoteNG.Config;
+using mRemoteNG.Connection;
+using mRemoteNG.Connection.Protocol;
+using mRemoteNG.Properties;
+using mRemoteNG.UI.Tabs;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.UI.Tabs
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    [NonParallelizable]
+    public class ConnectionTabCloseTests
+    {
+        private StubProtocol _protocol = null!;
+        private ConnectionTab _connectionTab = null!;
+        private InterfaceControl _interfaceControl = null!;
+        private int _originalConfirmCloseConnection;
+        private bool _originalKeepTabsOpenAfterDisconnect;
+
+        [SetUp]
+        public void Setup()
+        {
+            _originalConfirmCloseConnection = Settings.Default.ConfirmCloseConnection;
+            _originalKeepTabsOpenAfterDisconnect = OptionsTabsPanelsPage.Default.KeepTabsOpenAfterDisconnect;
+
+            // Never prompt - the fixture must stay headless.
+            Settings.Default.ConfirmCloseConnection = (int)ConfirmCloseEnum.Never;
+            OptionsTabsPanelsPage.Default.KeepTabsOpenAfterDisconnect = true;
+
+            _protocol = new StubProtocol();
+            _connectionTab = new ConnectionTab { TabText = "SSH2: Connection Name" };
+
+            ConnectionInfo connectionInfo = new()
+            {
+                Protocol = ProtocolType.SSH2,
+                Name = "Connection Name",
+                Hostname = "example-host"
+            };
+
+            _interfaceControl = new InterfaceControl(_connectionTab, _protocol, connectionInfo);
+            _protocol.InterfaceControl = _interfaceControl;
+            _connectionTab.Tag = _interfaceControl;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Settings.Default.ConfirmCloseConnection = _originalConfirmCloseConnection;
+            OptionsTabsPanelsPage.Default.KeepTabsOpenAfterDisconnect = _originalKeepTabsOpenAfterDisconnect;
+
+            _interfaceControl?.Dispose();
+            _connectionTab?.Dispose();
+        }
+
+        [Test]
+        public void ClosingTheTabClosesItEvenWhenTabsAreKeptOpenAfterDisconnect()
+        {
+            FormClosingEventArgs closingArgs = InvokeFormClosing();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closingArgs.Cancel, Is.False,
+                            "Closing the tab must close the tab - KeepTabsOpenAfterDisconnect only covers a disconnect.");
+                Assert.That(_protocol.CloseCallCount, Is.EqualTo(1), "The protocol should still be disconnected.");
+            });
+        }
+
+        [Test]
+        public void DisconnectingFromTheTabMenuKeepsTheTabOpenWhenTabsAreKeptOpenAfterDisconnect()
+        {
+            _connectionTab.disconnectOnly = true;
+
+            FormClosingEventArgs closingArgs = InvokeFormClosing();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closingArgs.Cancel, Is.True,
+                            "A disconnect request should leave the tab in place so it can show the reconnect panel.");
+                Assert.That(_protocol.CloseCallCount, Is.EqualTo(1), "The protocol should be disconnected.");
+            });
+        }
+
+        [Test]
+        public void DisconnectingFromTheTabMenuClosesTheTabWhenTabsAreNotKeptOpenAfterDisconnect()
+        {
+            OptionsTabsPanelsPage.Default.KeepTabsOpenAfterDisconnect = false;
+            _connectionTab.disconnectOnly = true;
+
+            FormClosingEventArgs closingArgs = InvokeFormClosing();
+
+            Assert.That(closingArgs.Cancel, Is.False);
+        }
+
+        private FormClosingEventArgs InvokeFormClosing()
+        {
+            FormClosingEventArgs closingArgs = new(CloseReason.UserClosing, false);
+
+            MethodInfo onFormClosing = typeof(ConnectionTab)
+                                           .GetMethod("OnFormClosing", BindingFlags.Instance | BindingFlags.NonPublic)
+                                       ?? throw new AssertionException("Failed to resolve ConnectionTab.OnFormClosing.");
+
+            onFormClosing.Invoke(_connectionTab, [closingArgs]);
+
+            return closingArgs;
+        }
+
+        /// <summary>
+        /// Stands in for a live protocol: it reports the disconnect without starting the
+        /// background close thread that <see cref="ProtocolBase.Close"/> would spawn.
+        /// </summary>
+        private sealed class StubProtocol : ProtocolBase
+        {
+            public int CloseCallCount { get; private set; }
+
+            public override void Close()
+            {
+                CloseCallCount++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closing a PuTTY session from the tab's X asked the user to confirm twice, and the tab stayed behind afterwards.

## The double prompt

`TryClosePuttyGracefully` posts `WM_CLOSE`, and PuTTY answers that with its own warn-on-close box ("Are you sure you want to close this session?") — on top of the confirmation mRemoteNG had just shown. The wait for the process to exit now polls every 50 ms (same 1 s budget as before) and acknowledges that box on the user's behalf.

The match is deliberately narrow — owning process, dialog class `#32770`, and an "Exit Confirmation" title — so PuTTY's host key **Security Alert** and the settings dialog are never auto-answered. That predicate is extracted as `PuttyBase.IsPuttyExitConfirmation` and covered by tests.

Side effect: PuTTY now normally exits on its own instead of being killed after the 1 s timeout.

## The tab that would not close

`KeepTabsOpenAfterDisconnect` (**on** by default) cancelled the form close on every close path, so an explicitly closed tab stayed put showing the reconnect panel. That option now applies only to a disconnect request:

- tab context menu **Disconnect** → sets the new `disconnectOnly` flag → tab stays, reconnect panel shows (#61 behaviour, unchanged)
- tab **X** / Ctrl+W → the tab closes

`HandleProtocolClosed` also no longer revives a tab that is already disposing.

## Tests

New `ConnectionTabCloseTests` drives `ConnectionTab.OnFormClosing` with a stub protocol (headless — confirmation setting forced to Never) across all three combinations of close path and setting, plus 6 cases for `IsPuttyExitConfirmation` in `PuttyBaseTests`.

Full suite: 6379/6381. The 2 remaining failures are one pre-existing environment-dependent test (`StartupConnectionPathReturnsSavedPathWhenItIsTheSoleCandidate`, counted in two groups) that fails identically on a clean tree — a `confCons.xml` next to the test DLL wins over the temp path the test sets.