### PR TITLE
fix: restore connection tree state when the search filter is cleared

### DIFF
--- a/mRemoteNG/UI/Controls/ConnectionTree/ConnectionTree.cs
+++ b/mRemoteNG/UI/Controls/ConnectionTree/ConnectionTree.cs
@@ -36,6 +36,7 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
 
         private readonly ConnectionTreeSearchTextFilter _connectionTreeSearchTextFilter = new();
         private List<object>? _preFilterExpandedObjects;
+        private bool _columnAutoResizeSuspended;
 
         private bool _nodeInEditMode;
         private bool _allowEdit;
@@ -808,20 +809,38 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
         /// </summary>
         public void RemoveFilter()
         {
-            UseFiltering = false;
-            ResetColumnFiltering();
+            // Clearing the filter takes several passes: dropping UseFiltering and the column
+            // filter each run UpdateFiltering, then the tree is rebuilt below. Batch them —
+            // hold painting for the whole method so the intermediate states never reach the
+            // screen, and collapse the per-pass column auto-resize (which measures every
+            // visible row) into the single call at the end.
+            BeginUpdate();
+            _columnAutoResizeSuspended = true;
+            try
+            {
+                UseFiltering = false;
+                ResetColumnFiltering();
 
-            if (_preFilterExpandedObjects == null)
-                return;
+                if (_preFilterExpandedObjects != null)
+                {
+                    // Assigning ExpandedObjects only updates the tree model's expansion map; the
+                    // branch structure and the virtual list size keep the filtered layout until
+                    // the tree is rebuilt. Without the rebuild the tree renders the wrong
+                    // expand/collapse state and IndexOf() hands out row indexes that no longer
+                    // exist, which makes EnsureVisible throw. RebuildAll restores expansion and
+                    // the row list together.
+                    RebuildAll(SelectedObjects, _preFilterExpandedObjects, null);
+                    _preFilterExpandedObjects = null;
+                }
+            }
+            finally
+            {
+                _columnAutoResizeSuspended = false;
+                EndUpdate();
+            }
 
-            // Assigning ExpandedObjects only updates the tree model's expansion map; the branch
-            // structure and the virtual list size keep the filtered layout until the tree is
-            // rebuilt. Without the rebuild the tree renders the wrong expand/collapse state and
-            // IndexOf() hands out row indexes that no longer exist, which makes EnsureVisible
-            // throw. RebuildAll restores expansion and the row list together.
-            RebuildAll(SelectedObjects, _preFilterExpandedObjects, null);
-            _preFilterExpandedObjects = null;
-            AutoResizeColumn(Columns[0]);
+            if (Columns.Count > 0)
+                AutoResizeColumn(Columns[0]);
         }
 
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
@@ -909,6 +928,8 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
         protected override void UpdateFiltering()
         {
             base.UpdateFiltering();
+            if (_columnAutoResizeSuspended)
+                return;
             if (Columns.Count > 0)
                 AutoResizeColumn(Columns[0]);
         }

--- a/mRemoteNG/UI/Controls/ConnectionTree/ConnectionTree.cs
+++ b/mRemoteNG/UI/Controls/ConnectionTree/ConnectionTree.cs
@@ -35,7 +35,7 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
         private ThemeManager _themeManager;
 
         private readonly ConnectionTreeSearchTextFilter _connectionTreeSearchTextFilter = new();
-        private System.Collections.IEnumerable? _preFilterExpandedObjects;
+        private List<object>? _preFilterExpandedObjects;
 
         private bool _nodeInEditMode;
         private bool _allowEdit;
@@ -770,7 +770,7 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
             {
                 // Update the pre-filter expanded state to include all containers
                 // so that when the filter is cleared, everything stays expanded.
-                var allContainers = new List<ContainerInfo>();
+                var allContainers = new List<object>();
                 if (ConnectionTreeModel != null)
                 {
                     foreach (ContainerInfo root in ConnectionTreeModel.RootNodes)
@@ -791,7 +791,10 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
         {
             if (!UseFiltering)
             {
-                _preFilterExpandedObjects = ExpandedObjects;
+                // ExpandedObjects is a live view over the tree model's internal map, not a
+                // snapshot. Copy it, otherwise the ExpandAll() below rewrites the "pre-filter"
+                // state and RemoveFilter() ends up restoring from a collection it just cleared.
+                _preFilterExpandedObjects = ExpandedObjects.Cast<object>().ToList();
             }
 
             UseFiltering = true;
@@ -808,11 +811,17 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
             UseFiltering = false;
             ResetColumnFiltering();
 
-            if (_preFilterExpandedObjects != null)
-            {
-                ExpandedObjects = _preFilterExpandedObjects;
-                _preFilterExpandedObjects = null;
-            }
+            if (_preFilterExpandedObjects == null)
+                return;
+
+            // Assigning ExpandedObjects only updates the tree model's expansion map; the branch
+            // structure and the virtual list size keep the filtered layout until the tree is
+            // rebuilt. Without the rebuild the tree renders the wrong expand/collapse state and
+            // IndexOf() hands out row indexes that no longer exist, which makes EnsureVisible
+            // throw. RebuildAll restores expansion and the row list together.
+            RebuildAll(SelectedObjects, _preFilterExpandedObjects, null);
+            _preFilterExpandedObjects = null;
+            AutoResizeColumn(Columns[0]);
         }
 
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/mRemoteNGTests/UI/Controls/ConnectionTreeExpansionTests.cs
+++ b/mRemoteNGTests/UI/Controls/ConnectionTreeExpansionTests.cs
@@ -172,5 +172,90 @@ namespace mRemoteNGTests.UI.Controls
                 Assert.That(tree.IsExpanded(folder2), Is.True, "Folder2 should be expanded");
             });
         }
+
+        [Test]
+        public void RemoveFilter_RestoresPreFilterExpansionState()
+        {
+            RunWithMessagePump(tree =>
+            {
+                var model = new ConnectionTreeModel();
+                var root = new RootNodeInfo(RootNodeType.Connection);
+
+                var folder1 = new ContainerInfo { Name = "Folder1" };
+                folder1.AddChild(new ConnectionInfo { Name = "Match" });
+
+                var folder2 = new ContainerInfo { Name = "Folder2" };
+                folder2.AddChild(new ConnectionInfo { Name = "NoMatch" });
+
+                root.AddChild(folder1);
+                root.AddChild(folder2);
+
+                model.AddRootNode(root);
+                tree.ConnectionTreeModel = model;
+
+                tree.CollapseAll();
+                tree.Expand(root);
+                tree.Expand(folder1);
+                Application.DoEvents();
+
+                tree.ApplyFilter("Match");
+                Application.DoEvents();
+                Assert.That(tree.IsExpanded(folder2), Is.True, "Filtering expands everything");
+
+                tree.RemoveFilter();
+                Application.DoEvents();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(tree.IsExpanded(root), Is.True, "Root was expanded before filtering");
+                    Assert.That(tree.IsExpanded(folder1), Is.True, "Folder1 was expanded before filtering");
+                    Assert.That(tree.IsExpanded(folder2), Is.False, "Folder2 was collapsed before filtering");
+                });
+            });
+        }
+
+        [Test]
+        public void RemoveFilter_RebuildsRowsToMatchRestoredExpansionState()
+        {
+            RunWithMessagePump(tree =>
+            {
+                var model = new ConnectionTreeModel();
+                var root = new RootNodeInfo(RootNodeType.Connection);
+
+                var folder1 = new ContainerInfo { Name = "Folder1" };
+                var match = new ConnectionInfo { Name = "Match" };
+                folder1.AddChild(match);
+
+                var folder2 = new ContainerInfo { Name = "Folder2" };
+                folder2.AddChild(new ConnectionInfo { Name = "NoMatch" });
+
+                root.AddChild(folder1);
+                root.AddChild(folder2);
+
+                model.AddRootNode(root);
+                tree.ConnectionTreeModel = model;
+
+                tree.CollapseAll();
+                tree.Expand(root);
+                tree.Expand(folder1);
+                Application.DoEvents();
+
+                int rowsBeforeFilter = tree.GetItemCount();
+
+                tree.ApplyFilter("Match");
+                Application.DoEvents();
+
+                tree.RemoveFilter();
+                Application.DoEvents();
+
+                // Restoring the expansion map without rebuilding leaves the rows in their
+                // filtered (fully expanded) layout, so row indexes no longer line up with
+                // what the tree reports as expanded — that mismatch is what makes
+                // EnsureVisible fail with an invalid index.
+                Assert.That(tree.GetItemCount(), Is.EqualTo(rowsBeforeFilter),
+                            "Row count should match the pre-filter expansion state");
+                Assert.DoesNotThrow(() => tree.EnsureModelVisible(match));
+            });
+        }
     }
 }


### PR DESCRIPTION
## Problem

Filtering the Connections tree with the search box and then clearing it leaves the tree broken: folders that were expanded before the filter come back collapsed, expand/collapse gets out of sync with what the tree reports, and in one case `EnsureVisible` threw on an invalid index.

## Root cause

Two compounding defects in `ConnectionTree.RemoveFilter()`:

**1. The "pre-filter" snapshot was not a snapshot.** `ApplyFilter` stored `ExpandedObjects`, whose getter returns a live `Dictionary.KeyCollection` over the tree model's expansion map (`TreeListView.cs:317`) rather than a copy. The `ExpandAll()` immediately after rewrote that same map, so the saved state became the filtered state. The `ExpandedObjects` setter then does `Clear()` *before* enumerating the value it was given — the very collection it just emptied — so `RemoveFilter` restored nothing and every folder collapsed.

**2. The display was never rebuilt.** Assigning `ExpandedObjects` only updates the model's map; OLV documents that `RebuildAll` must follow. `RemoveFilter` instead rebuilt first (via `ResetColumnFiltering`) and mutated the map afterwards, leaving the branch structure and row list on the filtered layout. Expansion state and row indexes then read from different sources, which is how `IndexOf` handed `EnsureVisible` a row index past the end of the list.

## Fix

- `_preFilterExpandedObjects` is materialized into a `List<object>` so it survives the `ExpandAll()`.
- `RemoveFilter` calls `RebuildAll(SelectedObjects, _preFilterExpandedObjects, null)`, restoring expansion, selection and the row list in one consistent pass.

## Follow-up commit: batching

Clearing the filter runs three passes — `UseFiltering` and the column filter reset each trigger `UpdateFiltering`, then the tree rebuild above. Each pass repainted and re-ran `AutoResizeColumn`, which measures the text of every visible row. The second commit holds painting across the whole method and collapses the three auto-resizes into one against the restored rows.

Note `Freeze()`/`Unfreeze()` is *not* usable here: the `if (Frozen) return;` guard lives in `ObjectListView.BuildList(bool)`, but `VirtualObjectListView` overrides that method without the guard, and `TreeListView` is a virtual list. Freezing would suspend painting while adding one more `BuildList` in `DoUnfreeze`.

## Tests

Two regression tests in `ConnectionTreeExpansionTests`, both verified to fail against the unfixed code:

| Test | Failure without the fix |
|---|---|
| `RemoveFilter_RestoresPreFilterExpansionState` | `Expected: True / But was: False` — root and Folder1 came back collapsed |
| `RemoveFilter_RebuildsRowsToMatchRestoredExpansionState` | `Expected: 4 / But was: 5` — rows kept the filtered layout |

Full suite on this branch: **6343 passed, 2 failed**. The failure (`StartupConnectionPathReturnsSavedPathWhenItIsTheSoleCandidate`, counted twice by overlapping groups) is pre-existing and unrelated — connections-file discovery picking up a candidate next to the test binary on the dev box; it fails in isolation on an unmodified tree too.
